### PR TITLE
Fix missing ciphers for TLS

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -31,6 +31,8 @@ import (
 	"syscall"
 	"time"
 
+	_ "crypto/tls" // Leave this to ensure that the TLS package is linked
+
 	"github.com/cyverse/go-irodsclient/icommands"
 	"github.com/cyverse/go-irodsclient/irods/types"
 	"github.com/cyverse/go-irodsclient/irods/util"


### PR DESCRIPTION
With some iRODS servers we observed SSL handshake failures because the client and server had no common ciphers supported. This was due to them not being included in the client build (not used directly).

This side-effect import fixes the issue.