### PR TITLE
Allow iRODS authentication without iinit icommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ active connections to close before shutting down.
 
 For additional options, use the `--help` flag.
 
+## iRODS authentication
+
+Sqyrrl uses the standard iRODS environment file to authenticate to iRODS. If the user has been
+authenticated with `iinit` before starting Sqyrrl, the server will use the existing iRODS auth
+file created by `iinit`. If the user has not been authenticated, Sqyrrl will require the iRODS
+password to be supplied using the environment variable `IRODS_PASSWORD`. Sqyrrl will then create
+the iRODS auth file itself, without requiring `iinit` to be used.
+
+## Running in a container
+
+When running Sqyrrl in a Docker container, configuration files (iRODS environment file, SSL
+certificates) should be mounted into the container and the password should be supplied using
+the environment variable `IRODS_PASSWORD`.
+
+The docker-compose.yml file in the repository contains an example configuration for running
+Sqyrrl in a container.
+
 ## Dependencies
 
 Sqyrrl uses [go-irodsclient](https://github.com/cyverse/go-irodsclient) to connect to iRODS. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,37 @@
 version: "3"
 
 services:
-  irods-server:
-    container_name: irods-server
-    image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
-    ports:
-      - "127.0.0.1:1247:1247"
-      - "127.0.0.1:20000-20199:20000-20199"
-    restart: always
+    irods-server:
+      container_name: irods-server
+      image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
+      ports:
+        - "1247:1247"
+        - "20000-20199:20000-20199"
+      restart: always
+      healthcheck:
+        test: ["CMD", "nc", "-z", "-v", "localhost", "1247"]
+        start_period: 30s
+        interval: 5s
+        timeout: 10s
+        retries: 12
 
-  app:
-    build:
+    app:
+      build:
         context: .
         dockerfile: Dockerfile
-    ports:
-      - "127.0.0.1:3333:3333"
-    depends_on:
-      - irods-server
+      command: ["start",
+                "--host", "0.0.0.0",
+                "--port", "3333",
+                "--cert-file", "/app/config/localhost.crt",
+                "--key-file", "/app/config/localhost.key",
+                "--irods-env", "/app/config/irods_environment.json",
+                "--log-level", "trace"]
+      environment:
+        IRODS_PASSWORD: "irods"
+      ports:
+        - "3333:3333"
+      volumes:
+        - ./config:/app/config
+      depends_on:
+        irods-server:
+          condition: service_healthy

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -63,7 +63,10 @@ var _ = BeforeSuite(func() {
 	err = manager.SetEnvironmentFilePath(iRODSEnvFile)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = server.InitIRODS(suiteLogger, manager, "irods")
+	err = os.Setenv(server.IRODSPasswordEnvVar, "irods")
+	Expect(err).NotTo(HaveOccurred())
+	authFilePath := manager.GetPasswordFilePath()
+	err = server.InitIRODS(suiteLogger, authFilePath, os.Getenv(server.IRODSPasswordEnvVar))
 	Expect(err).NotTo(HaveOccurred())
 
 	account, err = server.NewIRODSAccount(suiteLogger, manager)


### PR DESCRIPTION
This avoids the need for an external icommand (iinit) when authenticating with iRODS.

Add an environment variable to set the iRODS password.

Call an internal "iinit" equivalent function to create the auth file.