### PR TITLE
Add mapping of OIDC client user to iRODS user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build_args := -a -v -ldflags ${ldflags}
 
 build_path = build/sqyrrl-${VERSION}
 
-GOARCH := $(shell go env GOARCH)
+export GOARCH := $(shell go env GOARCH)
 
 CGO_ENABLED := 1
 
@@ -14,17 +14,17 @@ all: build
 
 build: build-linux build-darwin build-windows
 
-build-linux: GOOS = linux
+build-linux: export GOOS = linux
 build-linux:
 	mkdir -p ${build_path}
 	go build ${build_args} -o ${build_path}/sqyrrl-${GOOS}-${GOARCH} ./main.go
 
-build-darwin: GOOS = darwin
+build-darwin: export GOOS = darwin
 build-darwin:
 	mkdir -p ${build_path}
 	go build ${build_args} -o ${build_path}/sqyrrl-${GOOS}-${GOARCH} ./main.go
 
-build-windows: GOOS = windows
+build-windows: export GOOS = windows
 build-windows:
 	mkdir -p ${build_path}
 	go build ${build_args} -o ${build_path}/sqyrrl-${GOOS}-${GOARCH}.exe ./main.go

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ VERSION := $(shell git describe --always --tags --dirty)
 ldflags := "-X sqyrrl/server.Version=${VERSION}"
 build_args := -a -v -ldflags ${ldflags}
 
-build_path = "build/sqyrrl-${VERSION}"
+build_path = build/sqyrrl-${VERSION}
+
+GOARCH := amd64
 
 CGO_ENABLED := 1
-GOARCH := amd64
 
 .PHONY: build build-linux build-darwin build-windows check clean coverage install lint test
 
@@ -13,17 +14,20 @@ all: build
 
 build: build-linux build-darwin build-windows
 
+build-linux: GOOS = linux
 build-linux:
 	mkdir -p ${build_path}
-	GOARCH=${GOARCH} GOOS=linux go build ${build_args} -o ${build_path}/sqyrrl-linux-${GOARCH} ./main.go
+	go build ${build_args} -o ${build_path}/sqyrrl-${GOOS}-${GOARCH} ./main.go
 
+build-darwin: GOOS = darwin
 build-darwin:
 	mkdir -p ${build_path}
-	GOARCH=${GOARCH} GOOS=darwin go build ${build_args} -o ${build_path}/sqyrrl-darwin-${GOARCH} ./main.go
+	go build ${build_args} -o ${build_path}/sqyrrl-${GOOS}-${GOARCH} ./main.go
 
+build-windows: GOOS = windows
 build-windows:
 	mkdir -p ${build_path}
-	GOARCH=${GOARCH} GOOS=windows go build ${build_args} -o ${build_path}/sqyrrl-windows-${GOARCH}.exe ./main.go
+	go build ${build_args} -o ${build_path}/sqyrrl-${GOOS}-${GOARCH}.exe ./main.go
 
 install:
 	go install ${build_args}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build_args := -a -v -ldflags ${ldflags}
 
 build_path = build/sqyrrl-${VERSION}
 
-GOARCH := amd64
+GOARCH := $(shell go env GOARCH)
 
 CGO_ENABLED := 1
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,26 @@
 Sqyrrl is an HTTP server which contains an embedded iRODS client and is able to
 serve data directly from iRODS.
 
+## Building
+
+In the root directory of the repository run `make` to build Linux, macOS and Windows
+executables for the architecture of the machine you are on.
+
+To build for a different architecture, pass a Go architecture argument to make e.g.
+
+```
+make GOARCH=amd64  # To build for amd64
+
+make GOARCH=arm # To build for arm
+```
+
+You can find all the valid operating system and architecture pairs supported on your
+system by running `go tool dist list`
+
 ## Installation
 
-Sqyrrl is a available as and `amd64` binary for Linux, macOS and Windows,
-or as a Docker image. Copy the file to the desired location and run it.
+Sqyrrl runs on Linux, macOS and Windows. Copy the executable file to the desired location
+and run it. It is also available as a Docker image.
 
 ## Running Sqyrrl
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@
 services:
     irods-server:
       container_name: irods-server
-      image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
+      # image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.2:latest"
+      image: "wsinpg/ub-22.04-irods-4.3.3"
       platform: linux/amd64
       ports:
         - "127.0.0.1:1247:1247"
         - "127.0.0.1:20000-20199:20000-20199"
-      restart: always
+      restart: on-failure
       healthcheck:
         test: ["CMD", "nc", "-z", "-v", "127.0.0.1", "1247"]
         start_period: 30s
@@ -25,11 +26,7 @@ services:
       # The following environment variables may be set in a .env file (files named .env
       # are declared in .gitignore):
       #
-      # If no iRODS auth file is provided:
-      #
-      # IRODS_PASSWORD
-      #
-      # And if using OIDC:
+      # If using OIDC:
       #
       # OIDC_CLIENT_ID
       # OIDC_ISSUER_URL

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/alexedwards/scs/v2 v2.8.0
 	github.com/coreos/go-oidc/v3 v3.11.0
-	github.com/cyverse/go-irodsclient v0.14.4
+	github.com/cyverse/go-irodsclient v0.15.7-0.20241106203458-0b74740d1c86
 	github.com/microcosm-cc/bluemonday v1.0.26
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
@@ -27,6 +27,7 @@ require (
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
@@ -41,9 +42,8 @@ require (
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/tools v0.26.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // replace github.com/cyverse/go-irodsclient => ../go-irodsclient
-
-replace github.com/cyverse/go-irodsclient => github.com/wtsi-npg/go-irodsclient v0.0.0-20240417120912-4a4dec5bcefb

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDh
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyverse/go-irodsclient v0.15.7-0.20241106203458-0b74740d1c86 h1:/7oP8j3G42YhOSF8bSNQ7MbYNWPSYV53mw+mScymoic=
+github.com/cyverse/go-irodsclient v0.15.7-0.20241106203458-0b74740d1c86/go.mod h1:NN+PxHfLDUmsqfqSY84JfmqXS4EYiuiNW6ti6oPGCgk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
@@ -28,6 +30,8 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -66,8 +70,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/wtsi-npg/go-irodsclient v0.0.0-20240417120912-4a4dec5bcefb h1:42Ddz94sqVkcgdZjL2QyC2f0yiORTXaCMZAOqeGOFMU=
-github.com/wtsi-npg/go-irodsclient v0.0.0-20240417120912-4a4dec5bcefb/go.mod h1:eBXha3cwfrM0p1ijYVqsrLJQHpRwTfpA4c5dKCQsQFc=
 golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
 golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
@@ -93,5 +95,7 @@ google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojt
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -18,7 +18,7 @@
 package server_test
 
 import (
-	"fmt"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/cyverse/go-irodsclient/irods/connection"
-	"github.com/cyverse/go-irodsclient/irods/fs"
+	ifs "github.com/cyverse/go-irodsclient/irods/fs"
 	"github.com/cyverse/go-irodsclient/irods/types"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,52 +37,30 @@ import (
 )
 
 var _ = Describe("iRODS Get Handler", func() {
-	var testZone, rootColl, workColl string
+	var specTimeout = time.Second * 5
+	var workColl string
 	var testFile, localPath, remotePath string
-
-	var testConfig server.Config
-	var testServer *server.SqyrrlServer
 
 	BeforeEach(func(ctx SpecContext) {
 		// Put a test file into iRODS
-		testZone = "testZone"
-		rootColl = fmt.Sprintf("/%s/home/irods", testZone)
 		workColl = TmpRodsPath(rootColl, "iRODSGetHandler")
-
-		testConfig = server.Config{
-			Host:          "localhost",
-			Port:          "9999",
-			EnableOIDC:    false,
-			CertFilePath:  "./testdata/config/localhost.crt",
-			KeyFilePath:   "./testdata/config/localhost.key",
-			IndexInterval: time.Hour * 1,
-		}
-
-		var err error
-		err = server.Configure(suiteLogger, &testConfig)
-		Expect(err).NotTo(HaveOccurred())
-
-		testServer, err = server.NewSqyrrlServer(suiteLogger, &testConfig)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = testServer.StartBackground()
-		Expect(err).NotTo(HaveOccurred())
-
-		err = irodsFS.MakeDir(workColl, true)
+		err := irodsFS.MakeDir(workColl, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		testFile = "test.txt"
 		localPath = filepath.Join("testdata", testFile)
 		remotePath = path.Join(workColl, testFile)
 
-		err = irodsFS.UploadFile(localPath, remotePath, "", false, nil)
+		_, err = irodsFS.UploadFile(localPath, remotePath, "", false, true, true, nil)
 		Expect(err).NotTo(HaveOccurred())
 	}, NodeTimeout(time.Second*5))
 
 	AfterEach(func() {
-		testServer.Stop()
 		// Remove the test file from iRODS
-		err := irodsFS.RemoveDir(workColl, true, true)
+		err := irodsFS.RemoveFile(remotePath, true)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = irodsFS.RemoveDir(workColl, true, true)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -92,7 +70,7 @@ var _ = Describe("iRODS Get Handler", func() {
 		var err error
 
 		BeforeEach(func(ctx SpecContext) {
-			handler, err = testServer.GetHandler(server.EndpointIRODS)
+			handler, err = sqyrrlServer.GetHandler(server.EndpointIRODS)
 			Expect(err).NotTo(HaveOccurred())
 
 			objPath := path.Join(workColl, "no", "such", "file.txt")
@@ -108,91 +86,240 @@ var _ = Describe("iRODS Get Handler", func() {
 			handler.ServeHTTP(rec, r)
 
 			Expect(rec.Code).To(Equal(http.StatusNotFound))
-		}, SpecTimeout(time.Second*2))
+		}, SpecTimeout(specTimeout))
 	})
 
 	When("a valid data object path is given", func() {
-		var r *http.Request
-		var handler http.Handler
-		var err error
+		When("the Sqyrrl user is not authenticated", func() {
+			When("a valid data object path is given", func() {
+				var r *http.Request
+				var handler http.Handler
+				var err error
 
-		BeforeEach(func(ctx SpecContext) {
-			handler, err = testServer.GetHandler(server.EndpointIRODS)
-			Expect(err).NotTo(HaveOccurred())
+				BeforeEach(func(ctx SpecContext) {
+					handler, err = sqyrrlServer.GetHandler(server.EndpointIRODS)
+					Expect(err).NotTo(HaveOccurred())
 
-			objPath := path.Join(workColl, testFile)
-			getURL, err := url.JoinPath(server.EndpointIRODS, objPath)
-			Expect(err).NotTo(HaveOccurred())
+					objPath := path.Join(workColl, testFile)
+					getURL, err := url.JoinPath(server.EndpointIRODS, objPath)
+					Expect(err).NotTo(HaveOccurred())
 
-			r, err = http.NewRequest("GET", getURL, nil)
-			Expect(err).NotTo(HaveOccurred())
-		}, NodeTimeout(time.Second*2))
+					r, err = http.NewRequest("GET", getURL, nil)
+					Expect(err).NotTo(HaveOccurred())
+				}, NodeTimeout(time.Second*2))
 
-		When("the data object does not have public read permissions", func() {
-			It("should return Forbidden", func(ctx SpecContext) {
-				rec := httptest.NewRecorder()
-				handler.ServeHTTP(rec, r)
+				When("the data object does not have read permissions for the public group", func() {
+					It("should return Forbidden", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
 
-				Expect(rec.Code).To(Equal(http.StatusForbidden))
-			}, SpecTimeout(time.Second*2))
+						Expect(rec.Code).To(Equal(http.StatusForbidden))
+					}, SpecTimeout(specTimeout))
+				})
+
+				When("the data object has read permissions for the public group", func() {
+					var conn *connection.IRODSConnection
+
+					BeforeEach(func(ctx SpecContext) {
+						handler, err = sqyrrlServer.GetHandler(server.EndpointIRODS)
+						Expect(err).NotTo(HaveOccurred())
+
+						conn, err = irodsFS.GetIOConnection()
+						Expect(err).NotTo(HaveOccurred())
+
+						err = ifs.ChangeDataObjectAccess(conn, remotePath, types.IRODSAccessLevelReadObject,
+							server.IRODSPublicGroup, testZone, false)
+						Expect(err).NotTo(HaveOccurred())
+					}, NodeTimeout(time.Second*5))
+
+					AfterEach(func() {
+						err := irodsFS.ReturnIOConnection(conn)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should return OK", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
+
+						Expect(rec.Code).To(Equal(http.StatusOK))
+					}, SpecTimeout(specTimeout))
+
+					It("should serve the correct body content", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
+
+						Expect(rec.Code).To(Equal(http.StatusOK))
+						Expect(rec.Body.String()).To(Equal("test\n"))
+					}, SpecTimeout(specTimeout))
+				})
+			})
 		})
 
-		When("the data object has public read permissions", func() {
-			var conn *connection.IRODSConnection
-			var acl []*types.IRODSAccess
+		When("the Sqyrrl user is authenticated", func() {
+			var r *http.Request
+			var handler http.Handler
+			var err error
+
+			var accessToken = "test_access_token"
+			var sessionToken = "test_session_token"
 
 			BeforeEach(func(ctx SpecContext) {
-				handler, err = testServer.GetHandler(server.EndpointIRODS)
+				handler, err = sqyrrlServer.GetHandler(server.EndpointIRODS)
 				Expect(err).NotTo(HaveOccurred())
 
-				conn, err = irodsFS.GetIOConnection()
+				objPath := path.Join(workColl, testFile)
+				getURL, err := url.JoinPath(server.EndpointIRODS, objPath)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = fs.ChangeDataObjectAccess(conn, remotePath, types.IRODSAccessLevelReadObject,
-					server.IRODSPublicUser, testZone, false)
-				Expect(err).NotTo(HaveOccurred())
-
-				acl, err = irodsFS.ListFileACLsWithGroupUsers(remotePath)
-				Expect(err).NotTo(HaveOccurred())
-
-				var publicAccess bool
-				for _, ac := range acl {
-					suiteLogger.Info().
-						Str("user", ac.UserName).
-						Str("expected_user", server.IRODSPublicUser).
-						Str("zone", ac.UserZone).
-						Str("expected_zone", testZone).
-						Str("access", ac.AccessLevel.ChmodString()).
-						Str("expected_access", types.IRODSAccessLevelReadObject.ChmodString()).
-						Msg("ACL")
-
-					if ac.UserName == server.IRODSPublicUser &&
-						ac.UserZone == testZone &&
-						ac.AccessLevel == types.IRODSAccessLevelReadObject {
-						publicAccess = true
-					}
-				}
-				Expect(publicAccess).To(BeTrue())
-			}, NodeTimeout(time.Second*5))
-
-			AfterEach(func() {
-				irodsFS.ReturnIOConnection(conn)
+				r, err = http.NewRequest("GET", getURL, nil)
 			})
 
-			It("should return OK", func(ctx SpecContext) {
-				rec := httptest.NewRecorder()
-				handler.ServeHTTP(rec, r)
+			When("the user is not in the public group", func() {
+				BeforeEach(func(ctx SpecContext) {
+					// Populate a session as if the user has authenticated through OIDC
 
-				Expect(rec.Code).To(Equal(http.StatusOK))
-			}, SpecTimeout(time.Second*2))
+					var c context.Context
+					// There is no session for this token, so a new session will always be created
+					c, err = sessManager.Load(r.Context(), sessionToken)
+					sessManager.Put(c, server.SessionKeyAccessToken, accessToken)
+					sessManager.Put(c, server.SessionKeyUserName, userNotInPublic)
+					sessManager.Put(c, server.SessionKeyUserEmail, userNotInPublic+"@sanger.ac.uk")
+					r = r.WithContext(c)
 
-			It("should serve the correct body content", func(ctx SpecContext) {
-				rec := httptest.NewRecorder()
-				handler.ServeHTTP(rec, r)
+					// A real session token is created here, but we don't need it
+					_, _, err = sessManager.Commit(r.Context())
+					Expect(err).NotTo(HaveOccurred())
+				}, NodeTimeout(time.Second*2))
 
-				Expect(rec.Code).To(Equal(http.StatusOK))
-				Expect(rec.Body.String()).To(Equal("test\n"))
-			}, SpecTimeout(time.Second*2))
+				When("the data object does not have read permissions for the public group", func() {
+					It("should return Forbidden", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
+
+						Expect(rec.Code).To(Equal(http.StatusForbidden))
+					}, SpecTimeout(specTimeout))
+
+					When("the data object has read permissions for another of the user's groups", func() {
+						var conn *connection.IRODSConnection
+
+						BeforeEach(func(ctx SpecContext) {
+							handler, err = sqyrrlServer.GetHandler(server.EndpointIRODS)
+							Expect(err).NotTo(HaveOccurred())
+
+							conn, err = irodsFS.GetIOConnection()
+							Expect(err).NotTo(HaveOccurred())
+
+							err = ifs.ChangeDataObjectAccess(conn, remotePath, types.IRODSAccessLevelReadObject,
+								populatedGroup, testZone, false)
+							Expect(err).NotTo(HaveOccurred())
+						}, NodeTimeout(time.Second*5))
+
+						AfterEach(func() {
+							err := irodsFS.ReturnIOConnection(conn)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						It("should return OK", func(ctx SpecContext) {
+							rec := httptest.NewRecorder()
+							handler.ServeHTTP(rec, r)
+
+							Expect(rec.Code).To(Equal(http.StatusOK))
+						}, SpecTimeout(specTimeout))
+					})
+				})
+
+				When("the data object has read permissions for the public group", func() {
+					var conn *connection.IRODSConnection
+
+					BeforeEach(func(ctx SpecContext) {
+						handler, err = sqyrrlServer.GetHandler(server.EndpointIRODS)
+						Expect(err).NotTo(HaveOccurred())
+
+						conn, err = irodsFS.GetIOConnection()
+						Expect(err).NotTo(HaveOccurred())
+
+						err = ifs.ChangeDataObjectAccess(conn, remotePath, types.IRODSAccessLevelReadObject,
+							server.IRODSPublicGroup, testZone, false)
+						Expect(err).NotTo(HaveOccurred())
+					}, NodeTimeout(time.Second*5))
+
+					AfterEach(func() {
+						err := irodsFS.ReturnIOConnection(conn)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should return Forbidden", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
+
+						Expect(rec.Code).To(Equal(http.StatusForbidden))
+					}, SpecTimeout(specTimeout))
+				})
+			})
+
+			When("the user is in the public group", func() {
+				BeforeEach(func(ctx SpecContext) {
+					// Populate a session as if the user has authenticated through OIDC
+
+					var c context.Context
+					// There is no session for this token, so a new session will always be created
+					c, err = sessManager.Load(r.Context(), sessionToken)
+					sessManager.Put(c, server.SessionKeyAccessToken, accessToken)
+					sessManager.Put(c, server.SessionKeyUserName, userInPublic)
+					sessManager.Put(c, server.SessionKeyUserEmail, userInPublic+"@sanger.ac.uk")
+					r = r.WithContext(c)
+
+					// A real session token is created here, but we don't need it
+					_, _, err = sessManager.Commit(r.Context())
+					Expect(err).NotTo(HaveOccurred())
+				}, NodeTimeout(time.Second*2))
+
+				When("the data object does not have read permissions for the public group", func() {
+					It("should return Forbidden", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
+
+						Expect(rec.Code).To(Equal(http.StatusForbidden))
+					}, SpecTimeout(specTimeout))
+				})
+
+				When("the data object has read permissions for the public group", func() {
+					var conn *connection.IRODSConnection
+
+					BeforeEach(func(ctx SpecContext) {
+						handler, err = sqyrrlServer.GetHandler(server.EndpointIRODS)
+						Expect(err).NotTo(HaveOccurred())
+
+						conn, err = irodsFS.GetIOConnection()
+						Expect(err).NotTo(HaveOccurred())
+
+						err = ifs.ChangeDataObjectAccess(conn, remotePath, types.IRODSAccessLevelReadObject,
+							server.IRODSPublicGroup, testZone, false)
+						Expect(err).NotTo(HaveOccurred())
+					}, NodeTimeout(time.Second*5))
+
+					AfterEach(func() {
+						err := irodsFS.ReturnIOConnection(conn)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should return OK", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
+
+						Expect(rec.Code).To(Equal(http.StatusOK))
+					}, SpecTimeout(specTimeout))
+
+					It("should serve the correct body content", func(ctx SpecContext) {
+						rec := httptest.NewRecorder()
+						handler.ServeHTTP(rec, r)
+
+						Expect(rec.Code).To(Equal(http.StatusOK))
+						Expect(rec.Body.String()).To(Equal("test\n"))
+					}, SpecTimeout(specTimeout))
+
+				})
+			})
 		})
 	})
 })

--- a/server/irods_test.go
+++ b/server/irods_test.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2024. Genome Research Ltd. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package server_test
+
+import (
+	"github.com/cyverse/go-irodsclient/irods/connection"
+	"path"
+	"path/filepath"
+	"time"
+
+	ifs "github.com/cyverse/go-irodsclient/irods/fs"
+	"github.com/cyverse/go-irodsclient/irods/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sqyrrl/server"
+)
+
+var _ = Describe("iRODS functions", func() {
+	var conn *connection.IRODSConnection
+	var zone string
+	var workColl string
+	var testFile, localPath, remotePath string
+	var err error
+
+	BeforeEach(func(ctx SpecContext) {
+		zone = "testZone"
+		workColl = TmpRodsPath(rootColl, "iRODSGetHandler")
+		err = irodsFS.MakeDir(workColl, true)
+		Expect(err).NotTo(HaveOccurred())
+
+		testFile = "test.txt"
+		localPath = filepath.Join("testdata", testFile)
+		remotePath = path.Join(workColl, testFile)
+
+		_, err = irodsFS.UploadFile(localPath, remotePath, "", false, true, true, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		conn, err = irodsFS.GetIOConnection()
+		Expect(err).NotTo(HaveOccurred())
+	}, NodeTimeout(time.Second*5))
+
+	AfterEach(func() {
+		// Remove the test file from iRODS
+		err := irodsFS.RemoveDir(workColl, true, true)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = irodsFS.ReturnIOConnection(conn)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	When("a non-existent path is given", func() {
+		It("should return a FileNotFoundError", func() {
+			_, err := server.IsReadableByUser(suiteLogger, irodsFS, userInPublic,
+				zone, "/no/such/path")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(&types.FileNotFoundError{}))
+		})
+	})
+
+	When("a non-existent user is given", func() {
+		It("should return false", func() {
+			readable, err := server.IsReadableByUser(suiteLogger, irodsFS, "no_such_user",
+				zone, remotePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(readable).To(BeFalse())
+		})
+	})
+
+	When("a valid data object path is given", func() {
+		When("the data object has no permissions for the public group", func() {
+			BeforeEach(func(ctx SpecContext) {
+				err = ifs.ChangeDataObjectAccess(conn, remotePath,
+					types.IRODSAccessLevelNull, server.IRODSPublicGroup, testZone, false)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("the user is in the public group", func() {
+				It("should return false", func() {
+					readable, err := server.IsReadableByUser(suiteLogger, irodsFS, userInPublic,
+						zone, remotePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(readable).To(BeFalse())
+				})
+			})
+
+			When("the user is not in the public group", func() {
+				It("should return false", func() {
+					readable, err := server.IsReadableByUser(suiteLogger, irodsFS, userNotInPublic,
+						zone, remotePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(readable).To(BeFalse())
+				})
+			})
+		})
+
+		When("the data object has read permissions for the public group", func() {
+			BeforeEach(func(ctx SpecContext) {
+				err = ifs.ChangeDataObjectAccess(conn, remotePath,
+					types.IRODSAccessLevelReadObject, server.IRODSPublicGroup, testZone, false)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("the user is in the public group", func() {
+				It("should return true", func() {
+					readable, err := server.IsReadableByUser(suiteLogger, irodsFS, userInPublic,
+						zone, remotePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(readable).To(BeTrue())
+				})
+			})
+
+			When("the user is not in the public group", func() {
+				It("should return false", func() {
+					readable, err := server.IsReadableByUser(suiteLogger, irodsFS, userNotInPublic,
+						zone, remotePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(readable).To(BeFalse())
+				})
+			})
+		})
+
+		When("the data object has own permissions for the public group", func() {
+			BeforeEach(func(ctx SpecContext) {
+				err = ifs.ChangeDataObjectAccess(conn, remotePath,
+					types.IRODSAccessLevelOwner, server.IRODSPublicGroup, testZone, false)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("the user is in the public group", func() {
+				It("should return true", func() {
+					readable, err := server.IsReadableByUser(suiteLogger, irodsFS, userInPublic,
+						zone, remotePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(readable).To(BeTrue())
+				})
+			})
+
+			When("the user is not in the public group", func() {
+				It("should return false", func() {
+					readable, err := server.IsReadableByUser(suiteLogger, irodsFS, userNotInPublic,
+						zone, remotePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(readable).To(BeFalse())
+				})
+			})
+		})
+	})
+})

--- a/server/routes.go
+++ b/server/routes.go
@@ -49,30 +49,30 @@ func (server *SqyrrlServer) addRoutes(mux *http.ServeMux) {
 
 	// See the home page template for the login/logout button that POSTs to these endpoints
 	loginHandler := sm.LoadAndSave(correlate(logRequest(HandleLogin(server))))
-	server.addRoute(mux, "POST", EndpointLogin, loginHandler)
+	server.AddRoute(mux, "POST", EndpointLogin, loginHandler)
 	logoutHandler := sm.LoadAndSave(correlate(logRequest(HandleLogout(server))))
-	server.addRoute(mux, "POST", EndpointLogout, logoutHandler)
+	server.AddRoute(mux, "POST", EndpointLogout, logoutHandler)
 
 	// OIDC authentication callback endpoint
 	authCallbackHandler := sm.LoadAndSave(correlate(logRequest(HandleAuthCallback(server))))
-	server.addRoute(mux, "GET", EndpointAuthCallback, authCallbackHandler)
+	server.AddRoute(mux, "GET", EndpointAuthCallback, authCallbackHandler)
 
 	// The static endpoint is used to serve static files from a filesystem embedded in
 	// the binary
 	staticHandler := sm.LoadAndSave(sanitiseURL(correlate(logRequest(getStatic))))
-	server.addRoute(mux, "GET", EndpointStatic, staticHandler)
+	server.AddRoute(mux, "GET", EndpointStatic, staticHandler)
 
 	// The API endpoint used to access files in iRODS
 	irodsGetHandler := sm.LoadAndSave(sanitiseURL(correlate(logRequest(getObject))))
-	server.addRoute(mux, "GET", EndpointIRODS, irodsGetHandler)
+	server.AddRoute(mux, "GET", EndpointIRODS, irodsGetHandler)
 
 	// The root endpoint hosts a home page. Any requests relative to it are redirected
 	// to the iRODS API endpoint
 	rootHandler := sm.LoadAndSave(sanitiseURL(correlate(logRequest(HandleHomePage(server)))))
-	server.addRoute(mux, "GET", EndpointRoot, rootHandler)
+	server.AddRoute(mux, "GET", EndpointRoot, rootHandler)
 }
 
-func (server *SqyrrlServer) addRoute(mux *http.ServeMux, method string, endpoint string,
+func (server *SqyrrlServer) AddRoute(mux *http.ServeMux, method string, endpoint string,
 	handler http.Handler) {
 	mux.Handle(method+" "+endpoint, handler)
 	server.handlers[endpoint] = handler

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -20,6 +20,9 @@ package server_test
 import (
 	"errors"
 	"fmt"
+	"github.com/alexedwards/scs/v2"
+	"github.com/cyverse/go-irodsclient/config"
+	"github.com/cyverse/go-irodsclient/irods/connection"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -27,6 +30,7 @@ import (
 	"time"
 
 	"github.com/cyverse/go-irodsclient/fs"
+	ifs "github.com/cyverse/go-irodsclient/irods/fs"
 	"github.com/cyverse/go-irodsclient/irods/types"
 	"github.com/rs/zerolog"
 
@@ -46,12 +50,24 @@ var (
 	iRODSEnvFilePath  = "testdata/config/test_irods_environment.json"
 	iRODSAuthFilePath = "testdata/config/test_auth_file"
 	iRODSPassword     = "irods"
+
+	testZone = "testZone"
+	rootColl = fmt.Sprintf("/%s/home/irods", testZone)
+
+	emptyGroup     = "empty_group"
+	populatedGroup = "populated_group"
+
+	userInPublic    = "user_in_public"
+	userNotInPublic = "user_not_in_public"
+
+	sqyrrlConfig server.Config
+	sessManager  *scs.SessionManager
+	sqyrrlServer *server.SqyrrlServer
 )
 
 func TestSuite(t *testing.T) {
 	writer := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}
-	suiteLogger = zerolog.New(writer).With().Timestamp().Logger().Level(zerolog.
-		DebugLevel)
+	suiteLogger = zerolog.New(writer).With().Timestamp().Logger().Level(zerolog.TraceLevel)
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, suiteName)
@@ -70,23 +86,148 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	manager, err := server.NewICommandsEnvironmentManager(suiteLogger, iRODSEnvFilePath)
+	// Set up iRODS account
+	var manager *config.ICommandsEnvironmentManager
+	manager, err = server.NewICommandsEnvironmentManager(suiteLogger, iRODSEnvFilePath)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = server.InitIRODS(suiteLogger, manager, iRODSPassword)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(manager.GetEnvironmentFilePath()).To(Equal(iRODSEnvFilePath))
-	Expect(manager.Password).To(Equal(iRODSPassword))
+
+	var iRODSEnvFilePathAbs string
+	iRODSEnvFilePathAbs, err = filepath.Abs(iRODSEnvFilePath)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(manager.EnvironmentFilePath).To(Equal(iRODSEnvFilePathAbs))
+	Expect(manager.Environment.Password).To(Equal(iRODSPassword))
 
 	account, err = server.NewIRODSAccount(suiteLogger, manager, iRODSPassword)
 	Expect(err).NotTo(HaveOccurred())
 
 	irodsFS, err = fs.NewFileSystemWithDefault(account, suiteName)
 	Expect(err).NotTo(HaveOccurred())
+
+	// Add iRODS users
+	var suiteConn *connection.IRODSConnection
+	suiteConn, err = irodsFS.GetIOConnection()
+	Expect(err).NotTo(HaveOccurred())
+
+	defer func(irodsFS *fs.FileSystem, conn *connection.IRODSConnection) {
+		err := irodsFS.ReturnIOConnection(conn)
+		if err != nil {
+			suiteLogger.Error().Err(err).Msg("Failed to return iRODS connection cleanly")
+		}
+	}(irodsFS, suiteConn)
+
+	testUsers := []string{userInPublic, userNotInPublic}
+	currentUsers := make(map[string]struct{})
+
+	var users []*types.IRODSUser
+	users, err = ifs.ListUsers(suiteConn)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, u := range users {
+		currentUsers[u.Name] = struct{}{}
+	}
+
+	for _, userName := range testUsers {
+		if _, ok := currentUsers[userName]; !ok {
+			err = ifs.CreateUser(suiteConn, userName, testZone, string(types.IRODSUserRodsUser))
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	testGroups := []string{emptyGroup, populatedGroup}
+	currentGroups := make(map[string]struct{})
+
+	var groups []*types.IRODSUser
+	groups, err = ifs.ListGroups(suiteConn)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, g := range groups {
+		currentGroups[g.Name] = struct{}{}
+	}
+
+	for _, groupName := range testGroups {
+		if _, ok := currentGroups[groupName]; !ok {
+			err = ifs.CreateGroup(suiteConn, groupName, string(types.IRODSUserRodsGroup))
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	// None of the following group membership operations clear the go-irodsclient cache
+	// so calls via FileSystem will still return the old data. There doesn't appear to
+	// be a way to clear the user/group membership cache, so we work around this by
+	// replacing the irodsFS object with a new one.
+
+	var inGroup bool
+	// Ensure userInPublic is in the public group
+	inGroup, err = server.UserInGroup(suiteLogger, irodsFS, userInPublic, testZone, server.IRODSPublicGroup)
+	Expect(err).NotTo(HaveOccurred())
+	if !inGroup {
+		err = ifs.AddGroupMember(suiteConn, server.IRODSPublicGroup, userInPublic, testZone)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// Ensure userNotInPublic is not in the public group
+	inGroup, err = server.UserInGroup(suiteLogger, irodsFS, userNotInPublic, testZone, server.IRODSPublicGroup)
+	Expect(err).NotTo(HaveOccurred())
+	if inGroup {
+		err = ifs.RemoveGroupMember(suiteConn, server.IRODSPublicGroup, userNotInPublic, testZone)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// Ensure userNotInPublic is in the populated group
+	inGroup, err = server.UserInGroup(suiteLogger, irodsFS, userNotInPublic, testZone, populatedGroup)
+	Expect(err).NotTo(HaveOccurred())
+	if !inGroup {
+		err = ifs.AddGroupMember(suiteConn, populatedGroup, userNotInPublic, testZone)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// Replace irodsFS with a new instance to clear the cache
+	irodsFS.Release()
+	irodsFS, err = fs.NewFileSystemWithDefault(account, suiteName)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Check that the group membership operations were successful
+	inGroup, err = server.UserInGroup(suiteLogger, irodsFS, userInPublic, testZone, server.IRODSPublicGroup)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(inGroup).To(BeTrue())
+
+	inGroup, err = server.UserInGroup(suiteLogger, irodsFS, userNotInPublic, testZone, server.IRODSPublicGroup)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(inGroup).To(BeFalse())
+
+	inGroup, err = server.UserInGroup(suiteLogger, irodsFS, userNotInPublic, testZone, populatedGroup)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(inGroup).To(BeTrue())
+
+	// OIDC is not enabled for testing. We test for authenticated cases by creating
+	// a session manager and populating it with a session that simulates OIDC
+	// authentication.
+	sqyrrlConfig = server.Config{
+		Host:          "127.0.0.1",
+		Port:          "9999",
+		CertFilePath:  "./testdata/config/localhost.crt",
+		KeyFilePath:   "./testdata/config/localhost.key",
+		IndexInterval: time.Hour * 1,
+		EnableOIDC:    false,
+	}
+	sessManager = scs.New()
+
+	err = server.Configure(suiteLogger, &sqyrrlConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	sqyrrlServer, err = server.NewSqyrrlServer(suiteLogger, &sqyrrlConfig, sessManager)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = sqyrrlServer.StartBackground()
+	Expect(err).NotTo(HaveOccurred())
 }, NodeTimeout(time.Second*20))
 
 // Release the iRODS filesystem
 var _ = AfterSuite(func() {
+	sqyrrlServer.Stop()
 	irodsFS.Release()
 
 	// Clean up any auth file that may have been created

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"crypto/tls"
+	"github.com/alexedwards/scs/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -39,7 +40,7 @@ var _ = Describe("Server startup and shutdown", func() {
 
 	When("a server is created", func() {
 		It("can be started and stopped", func() {
-			srv, err := server.NewSqyrrlServer(suiteLogger, &config)
+			srv, err := server.NewSqyrrlServer(suiteLogger, &config, scs.New())
 			Expect(err).NotTo(HaveOccurred())
 
 			var startStopErr error
@@ -112,7 +113,7 @@ var _ = Describe("Server startup and shutdown", func() {
 			config.IRODSEnvFilePath = "nonexistent.json"
 			err := server.Configure(suiteLogger, &config)
 
-			_, err = server.NewSqyrrlServer(suiteLogger, &config)
+			_, err = server.NewSqyrrlServer(suiteLogger, &config, scs.New())
 			Expect(err).To(MatchError("stat nonexistent.json: no such file or directory"))
 		})
 	})


### PR DESCRIPTION
When OIDC is enabled, switch off Sqyrrl's current mode of showing only public (iRODS group) data, but showing it to all clients.

Instead, when OIDC is enabled, Sqyrrl maps the authenticated OIDC client user to an iRODS user of the same name and then uses the standard iRODS permissions model. In this mode a client can see "public" data only if their mapped iRODS user is a member of the public iRODS group.

Sqyrrl's HTTP session manager is now passed to its constructor so that it is accessible to be externally configured and also to simplify testing because fake OIDC sessions can be set up to test the HTTP handlers, without the need for an OIDC server or mocks.