### PR TITLE
Group acl logic and config

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -347,7 +347,7 @@ func HandleIRODSGet(server *SqyrrlServer) http.Handler {
 			// zone. We use the local zone to which the  Sqyrrl server is connected as
 			// the user's zone.
 			userName := iRODSUsernameFromEmail(logger, server.getSessionUserEmail(r))
-			userZone := localZone
+			userZone := server.sqyrrlConfig.IRODSZoneForOIDC
 
 			logger.Debug().Str("user", userName).Msg("User is authenticated")
 

--- a/server/irods.go
+++ b/server/irods.go
@@ -219,6 +219,12 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 		}
 	}
 	if !localUserExists {
+		logger.Trace().
+			Str("path", rodsPath).
+			Str("user", userName).
+			Str("zone", userZone).
+			Bool("localUserExists", localUserExists).
+			Msg("No local iRODS user")
 		return false, nil
 	}
 

--- a/server/irods.go
+++ b/server/irods.go
@@ -311,33 +311,47 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 			// - acUserZone is for the group whilst userZone is for the user (in the group)
 			// - groups (assumed to be) only for the zone being served - no federation of groups
 			// - equivalent zone check is done in the group membership logic
-			if acUserZone == localZone && userInGroup && (hasRead || hasOwn) {
+			if acUserZone == localZone {
+				if userInGroup && (hasRead || hasOwn) {
+					logger.Trace().
+						Str("path", rodsPath).
+						Str("user", userName).
+						Str("zone", userZone).
+						Str("ac_user(group)", ac.UserName).
+						Str("ac_zone(group)", acUserZone).
+						Str("ac_level", string(ac.AccessLevel)).
+						Bool("read", hasRead).
+						Bool("own", hasOwn).
+						Bool("user_in_group", userInGroup).
+						Msg("Group access found")
+
+					return true, nil
+				}
+
 				logger.Trace().
 					Str("path", rodsPath).
 					Str("user", userName).
 					Str("zone", userZone).
 					Str("ac_user(group)", ac.UserName).
-					Str("ac_zone(group)", acUserZone).
+					Str("ac(group)", acUserZone).
 					Str("ac_level", string(ac.AccessLevel)).
 					Bool("read", hasRead).
 					Bool("own", hasOwn).
 					Bool("user_in_group", userInGroup).
-					Msg("Group access found")
-
-				return true, nil
+					Msg("Group access not found")
+			} else {
+				logger.Warn().
+					Str("path", rodsPath).
+					Str("user", userName).
+					Str("zone", userZone).
+					Str("ac_user(group)", ac.UserName).
+					Str("ac(group)", acUserZone).
+					Str("ac_level", string(ac.AccessLevel)).
+					Bool("read", hasRead).
+					Bool("own", hasOwn).
+					Bool("user_in_group", userInGroup).
+					Msg("Developer assumption of groups only being available for local zone broken")
 			}
-
-			logger.Trace().
-				Str("path", rodsPath).
-				Str("user", userName).
-				Str("zone", userZone).
-				Str("ac_user(group)", ac.UserName).
-				Str("ac(group)", acUserZone).
-				Str("ac_level", string(ac.AccessLevel)).
-				Bool("read", hasRead).
-				Bool("own", hasOwn).
-				Bool("user_in_group", userInGroup).
-				Msg("Group access not found")
 
 		default:
 			logger.Error().

--- a/server/irods.go
+++ b/server/irods.go
@@ -233,6 +233,12 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 	}
 
 	var userGroups []*types.IRODSUser
+	// WARNING: go-irodsclient is currently zone/federation unaware.
+	// The iRODS zone used together with OIDC user ids, and which is used for checking
+	// user based ACLs, cannot be used when checking (the membership of) groups used for
+	// iRODS ACLs. i.e. we would ideally be calling something like
+	//   userGroups, err = filesystem.ListUserGroups(userName, userZone)
+	// instead of the following:
 	userGroups, err = filesystem.ListUserGroups(userName)
 	if err != nil {
 		return false, err

--- a/server/irods.go
+++ b/server/irods.go
@@ -301,13 +301,17 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 			// Check if user in the group of this AC (ac.UserName is the name of the AC's group, unfortunately)
 			_, userInGroup := userGroupLookup[ac.UserName]
 
-			if acUserZone == userZone && userInGroup && (hasRead || hasOwn) {
+			// note a "acUserZone == userZone" check would be wrong here as:
+			// - acUserZone is for the group whilst userZone is for the user (in the group)
+			// - groups (assumed to be) only for the zone being served - no federation of groups
+			// - equivalent zone check is done in the group membership logic
+			if acUserZone == localZone && userInGroup && (hasRead || hasOwn) {
 				logger.Trace().
 					Str("path", rodsPath).
 					Str("user", userName).
 					Str("zone", userZone).
-					Str("ac_user", ac.UserName).
-					Str("ac_zone", acUserZone).
+					Str("ac_user(group)", ac.UserName).
+					Str("ac_zone(group)", acUserZone).
 					Str("ac_level", string(ac.AccessLevel)).
 					Bool("read", hasRead).
 					Bool("own", hasOwn).
@@ -321,8 +325,8 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 				Str("path", rodsPath).
 				Str("user", userName).
 				Str("zone", userZone).
-				Str("ac_user", ac.UserName).
-				Str("ac_zone", acUserZone).
+				Str("ac_user(group)", ac.UserName).
+				Str("ac(group)", acUserZone).
 				Str("ac_level", string(ac.AccessLevel)).
 				Bool("read", hasRead).
 				Bool("own", hasOwn).

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ type Config struct {
 	OIDCClientSecret string
 	OIDCIssuerURL    string
 	OIDCRedirectURL  string
+	IRODSZoneForOIDC string // iRODS zone to use with OIDC id for authz
 	IndexInterval    time.Duration
 }
 
@@ -234,6 +235,11 @@ func NewSqyrrlServer(logger zerolog.Logger, config *Config,
 	if iRODSAccount, err = NewIRODSAccount(subLogger, iRODSEnvManager, config.IRODSPassword); err != nil {
 		logger.Err(err).Msg("Failed to get an iRODS account")
 		return nil, err
+	}
+
+	if config.IRODSZoneForOIDC == "" {
+		config.IRODSZoneForOIDC = iRODSAccount.ClientZone
+		logger.Debug().Str("IRODSZoneForOIDC", config.IRODSZoneForOIDC).Msg("Setting IRODSZoneForOIDC to default of client zone")
 	}
 
 	addr := net.JoinHostPort(config.Host, config.Port)


### PR DESCRIPTION
Fix to some of the zone logic for groups ACL implementation.
Add ability to config zone for OIDC users (as may not match zone of server connected to, or that of the service account being used to connect to iRODS) - needed for valid user check [ and user ACL logic] even though not used in group ACL logic.
Note limitation of group ACL logic being zone unaware.
