### PR TITLE
Refine access control logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,3 +47,4 @@ require (
 )
 
 // replace github.com/cyverse/go-irodsclient => ../go-irodsclient
+replace github.com/cyverse/go-irodsclient => github.com/wtsi-npg/go-irodsclient v0.0.0-20250110165023-801d97d497e6

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDh
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyverse/go-irodsclient v0.15.7-0.20241106203458-0b74740d1c86 h1:/7oP8j3G42YhOSF8bSNQ7MbYNWPSYV53mw+mScymoic=
-github.com/cyverse/go-irodsclient v0.15.7-0.20241106203458-0b74740d1c86/go.mod h1:NN+PxHfLDUmsqfqSY84JfmqXS4EYiuiNW6ti6oPGCgk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
@@ -70,6 +68,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/wtsi-npg/go-irodsclient v0.0.0-20250110165023-801d97d497e6 h1:Fu+mJYC4TRWF2CoChHa+10TC7eeG6v+fhjGb7ZA0kBk=
+github.com/wtsi-npg/go-irodsclient v0.0.0-20250110165023-801d97d497e6/go.mod h1:NN+PxHfLDUmsqfqSY84JfmqXS4EYiuiNW6ti6oPGCgk=
 golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
 golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -369,7 +369,7 @@ func HandleIRODSGet(server *SqyrrlServer) http.Handler {
 			}
 		} else {
 			logger.Debug().Msg("User is not authenticated")
-			isReadable, err = IsPublicReadable(logger, rodsFs, localZone, objPath)
+			isReadable, err = IsPublicReadable(logger, rodsFs, objPath)
 			if err != nil {
 				logger.Err(err).Msg("Failed to check if the object is public readable")
 				writeErrorResponse(logger, w, http.StatusInternalServerError)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -347,7 +347,7 @@ func HandleIRODSGet(server *SqyrrlServer) http.Handler {
 			// zone. We use the local zone to which the  Sqyrrl server is connected as
 			// the user's zone.
 			userName := iRODSUsernameFromEmail(logger, server.getSessionUserEmail(r))
-			userZone := localZone
+			userZone := server.sqyrrlConfig.IRODSZoneForOIDC
 
 			logger.Debug().Str("user", userName).Msg("User is authenticated")
 

--- a/server/irods.go
+++ b/server/irods.go
@@ -219,6 +219,12 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 		}
 	}
 	if !localUserExists {
+		logger.Trace().
+			Str("path", rodsPath).
+			Str("user", userName).
+			Str("zone", userZone).
+			Bool("localUserExists", localUserExists).
+			Msg("No local iRODS user")
 		return false, nil
 	}
 

--- a/server/irods.go
+++ b/server/irods.go
@@ -311,33 +311,47 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 			// - acUserZone is for the group whilst userZone is for the user (in the group)
 			// - groups (assumed to be) only for the zone being served - no federation of groups
 			// - equivalent zone check is done in the group membership logic
-			if acUserZone == localZone && userInGroup && (hasRead || hasOwn) {
+			if acUserZone == localZone {
+				if userInGroup && (hasRead || hasOwn) {
+					logger.Trace().
+						Str("path", rodsPath).
+						Str("user", userName).
+						Str("zone", userZone).
+						Str("ac_user(group)", ac.UserName).
+						Str("ac_zone(group)", acUserZone).
+						Str("ac_level", string(ac.AccessLevel)).
+						Bool("read", hasRead).
+						Bool("own", hasOwn).
+						Bool("user_in_group", userInGroup).
+						Msg("Group access found")
+
+					return true, nil
+				}
+
 				logger.Trace().
 					Str("path", rodsPath).
 					Str("user", userName).
 					Str("zone", userZone).
 					Str("ac_user(group)", ac.UserName).
-					Str("ac_zone(group)", acUserZone).
+					Str("ac(group)", acUserZone).
 					Str("ac_level", string(ac.AccessLevel)).
 					Bool("read", hasRead).
 					Bool("own", hasOwn).
 					Bool("user_in_group", userInGroup).
-					Msg("Group access found")
-
-				return true, nil
+					Msg("Group access not found")
+			} else {
+				logger.Warn().
+					Str("path", rodsPath).
+					Str("user", userName).
+					Str("zone", userZone).
+					Str("ac_user(group)", ac.UserName).
+					Str("ac(group)", acUserZone).
+					Str("ac_level", string(ac.AccessLevel)).
+					Bool("read", hasRead).
+					Bool("own", hasOwn).
+					Bool("user_in_group", userInGroup).
+					Msg("Developer assumption of groups only being available for local zone broken")
 			}
-
-			logger.Trace().
-				Str("path", rodsPath).
-				Str("user", userName).
-				Str("zone", userZone).
-				Str("ac_user(group)", ac.UserName).
-				Str("ac(group)", acUserZone).
-				Str("ac_level", string(ac.AccessLevel)).
-				Bool("read", hasRead).
-				Bool("own", hasOwn).
-				Bool("user_in_group", userInGroup).
-				Msg("Group access not found")
 
 		default:
 			logger.Error().

--- a/server/irods.go
+++ b/server/irods.go
@@ -383,7 +383,7 @@ func UserInGroup(logger zerolog.Logger, filesystem *ifs.FileSystem,
 }
 
 func IsPublicReadable(logger zerolog.Logger, filesystem *ifs.FileSystem,
-	userZone string, rodsPath string) (_ bool, err error) {
+	rodsPath string) (_ bool, err error) {
 	var acl []*types.IRODSAccess
 	if acl, err = filesystem.ListACLs(rodsPath); err != nil {
 		return false, err
@@ -391,7 +391,7 @@ func IsPublicReadable(logger zerolog.Logger, filesystem *ifs.FileSystem,
 
 	for _, ac := range acl {
 		if ac.UserName == IRODSPublicGroup &&
-			ac.UserZone == userZone &&
+			ac.UserType == types.IRODSUserRodsGroup &&
 			(ac.AccessLevel == types.IRODSAccessLevelReadObject ||
 				ac.AccessLevel == types.IRODSAccessLevelOwner) {
 			logger.Trace().

--- a/server/irods.go
+++ b/server/irods.go
@@ -233,6 +233,12 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 	}
 
 	var userGroups []*types.IRODSUser
+	// WARNING: go-irodsclient is currently zone/federation unaware.
+	// The iRODS zone used together with OIDC user ids, and which is used for checking
+	// user based ACLs, cannot be used when checking (the membership of) groups used for
+	// iRODS ACLs. i.e. we would ideally be calling something like
+	//   userGroups, err = filesystem.ListUserGroups(userName, userZone)
+	// instead of the following:
 	userGroups, err = filesystem.ListUserGroups(userName)
 	if err != nil {
 		return false, err

--- a/server/irods.go
+++ b/server/irods.go
@@ -301,13 +301,17 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 			// Check if user in the group of this AC (ac.UserName is the name of the AC's group, unfortunately)
 			_, userInGroup := userGroupLookup[ac.UserName]
 
-			if acUserZone == userZone && userInGroup && (hasRead || hasOwn) {
+			// note a "acUserZone == userZone" check would be wrong here as:
+			// - acUserZone is for the group whilst userZone is for the user (in the group)
+			// - groups (assumed to be) only for the zone being served - no federation of groups
+			// - equivalent zone check is done in the group membership logic
+			if acUserZone == localZone && userInGroup && (hasRead || hasOwn) {
 				logger.Trace().
 					Str("path", rodsPath).
 					Str("user", userName).
 					Str("zone", userZone).
-					Str("ac_user", ac.UserName).
-					Str("ac_zone", acUserZone).
+					Str("ac_user(group)", ac.UserName).
+					Str("ac_zone(group)", acUserZone).
 					Str("ac_level", string(ac.AccessLevel)).
 					Bool("read", hasRead).
 					Bool("own", hasOwn).
@@ -321,8 +325,8 @@ func IsReadableByUser(logger zerolog.Logger, filesystem *ifs.FileSystem,
 				Str("path", rodsPath).
 				Str("user", userName).
 				Str("zone", userZone).
-				Str("ac_user", ac.UserName).
-				Str("ac_zone", acUserZone).
+				Str("ac_user(group)", ac.UserName).
+				Str("ac(group)", acUserZone).
 				Str("ac_level", string(ac.AccessLevel)).
 				Bool("read", hasRead).
 				Bool("own", hasOwn).

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ type Config struct {
 	OIDCClientSecret string
 	OIDCIssuerURL    string
 	OIDCRedirectURL  string
+	IRODSZoneForOIDC string // iRODS zone to use with OIDC id for authz
 	IndexInterval    time.Duration
 }
 
@@ -234,6 +235,11 @@ func NewSqyrrlServer(logger zerolog.Logger, config *Config,
 	if iRODSAccount, err = NewIRODSAccount(subLogger, iRODSEnvManager, config.IRODSPassword); err != nil {
 		logger.Err(err).Msg("Failed to get an iRODS account")
 		return nil, err
+	}
+
+	if config.IRODSZoneForOIDC == "" {
+		config.IRODSZoneForOIDC = iRODSAccount.ClientZone
+		logger.Debug().Str("IRODSZoneForOIDC", config.IRODSZoneForOIDC).Msg("Setting IRODSZoneForOIDC to default of client zone")
 	}
 
 	addr := net.JoinHostPort(config.Host, config.Port)


### PR DESCRIPTION
Replaces [as is rebasing of] #87 and #90. This is on top of rebased #88.

Fix to some of the zone logic for groups ACL implementation, including zone checking for group membership.

Add ability to config zone for OIDC users (as may not match zone of server connected to, or that of the service account being used to connect to iRODS) - needed for valid user check, user ACL logic, and membership logic for group ACLs.

Also tweaks IsPublicReadable to
- remove vestigial/incorrect zone check
- check the public acl group being checked for is a group