### PR TITLE
Disable start of unused server in tests

### DIFF
--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -241,13 +241,14 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	sqyrrlServer, err = server.NewSqyrrlServer(suiteLogger, &sqyrrlConfig, sessManager)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = sqyrrlServer.StartBackground()
-	Expect(err).NotTo(HaveOccurred())
+	// server could be started here if testing with network connections e.g.
+	// err = sqyrrlServer.StartBackground()
+	// Expect(err).NotTo(HaveOccurred())
 }, NodeTimeout(time.Second*20))
 
 // Release the iRODS filesystem
 var _ = AfterSuite(func() {
-	sqyrrlServer.Stop()
+	sqyrrlServer.Stop() // no-op unless server has been started
 	irodsFS.Release()
 
 	// Clean up any auth file that may have been created


### PR DESCRIPTION
Network server is not actually currently used in the tests as Handlers are called directly.

Disabling to avoid possible confusion.

Leaving as comment as quite likely we might want to create tests using real network connections.