### PR TITLE
Cope with URL escaped characters in iRODS paths through seamless authn

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -24,6 +24,7 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"path"
 	"time"
 
@@ -61,7 +62,7 @@ func HandleHomePage(server *SqyrrlServer) http.Handler {
 				return
 			}
 
-			redirect := path.Join(EndpointIRODS, requestPath)
+			redirect := path.Join(EndpointIRODS, r.URL.EscapedPath())
 			logger.Trace().
 				Str("from", requestPath).
 				Str("to", redirect).
@@ -246,13 +247,16 @@ func HandleAuthCallback(server *SqyrrlServer) http.Handler {
 
 		logger.Debug().Msg("Redirecting logged in user to home page")
 		// find where to send the user after login - could be the home page or a path requiring auth
-		redirectUri := "/" + server.sessionManager.GetString(r.Context(), RedirectURIState)
+		redirectURI := server.sessionManager.GetString(r.Context(), RedirectURIState)
+		if redirectURI == "" {
+			redirectURI = EndpointRoot
+		}
 
 		logger.Debug().
-			Str("redirect_uri", redirectUri).
+			Str("redirect_uri", redirectURI).
 			Msg("Redirecting logged in user")
 
-		http.Redirect(w, r, redirectUri, http.StatusFound)
+		http.Redirect(w, r, redirectURI, http.StatusFound)
 	})
 }
 
@@ -317,14 +321,22 @@ func HandleIRODSGet(server *SqyrrlServer) http.Handler {
 			Str("correlation_id", corrID).
 			Str("irods", "get").Logger()
 
+		decodedPath, err := url.PathUnescape(r.URL.Path)
+		if err != nil {
+			corrLogger.Err(err).
+				Str("path", r.URL.Path).
+				Msg("Failed to decode request path")
+			writeErrorResponse(corrLogger, w, http.StatusBadRequest)
+			return
+		}
+
 		// The path should be clean as it has passed through the ServeMux, but since we're
-		// doing a path.Join, clean it before passing it to iRODS
-		objPath := path.Clean(path.Join("/", r.URL.Path))
+		// doing a path.Join, clean it before passing it to iRODS.
+		objPath := path.Clean(path.Join("/", decodedPath))
 
 		pathLogger := corrLogger.With().Str("path", objPath).Logger()
 		pathLogger.Debug().Msg("Getting iRODS data object")
 
-		var err error
 		var rodsFs *ifs.FileSystem
 		if rodsFs, err = ifs.NewFileSystemWithDefault(server.iRODSAccount, AppName); err != nil {
 			pathLogger.Err(err).Msg("Failed to create an iRODS file system")
@@ -392,7 +404,9 @@ func HandleIRODSGet(server *SqyrrlServer) http.Handler {
 				if server.sqyrrlConfig.EnableOIDC {
 					pathLogger.Debug().Msg("User is not authenticated")
 					pathLogger.Info().Msg("Requested path is not public readable - redirecting to login")
-					RedirectToIdentityServer(w, r, server, r.URL.Path)
+
+					loginRedirect := path.Join(EndpointIRODS, r.URL.EscapedPath())
+					RedirectToIdentityServer(w, r, server, loginRedirect)
 				} else {
 					pathLogger.Info().Msg("Requested path is not public readable - and no OIDC enabled")
 					writeErrorResponse(pathLogger, w, http.StatusForbidden)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cyverse/go-irodsclient/irods/connection"
@@ -503,7 +504,7 @@ var _ = Describe("Seamless Auth Flow", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	When("Accessing a file marked with the public group", func() {
+	When("Accessing a file marked with the public group via the API endpoint", func() {
 		var conn *connection.IRODSConnection
 
 		BeforeEach(func(ctx SpecContext) {
@@ -541,6 +542,57 @@ var _ = Describe("Seamless Auth Flow", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(bodyBytes)).To(Equal("test\n"))
 		}, NodeTimeout(time.Second*2))
+	})
+
+	When("Accessing a public file whose hash path is requested from the site root", func() {
+		var conn *connection.IRODSConnection
+		var hashRemotePath string
+
+		BeforeEach(func(ctx SpecContext) {
+			var err error
+			conn, err = irodsFS.GetIOConnection()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = irodsFS.MakeDir(workColl, true)
+			Expect(err).NotTo(HaveOccurred())
+
+			hashRemotePath = path.Join(workColl, "hash#test.txt")
+			_, err = irodsFS.UploadFile(localPath, hashRemotePath, "", false, true, true, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = ifs.ChangeDataObjectAccess(conn, hashRemotePath, types.IRODSAccessLevelReadObject,
+				server.IRODSPublicGroup, testZone, false)
+			Expect(err).NotTo(HaveOccurred())
+		}, NodeTimeout(time.Second*5))
+
+		AfterEach(func() {
+			err := irodsFS.RemoveFile(hashRemotePath, true)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = irodsFS.ReturnIOConnection(conn)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return a 200 OK and correct content", func(ctx SpecContext) {
+			httpClient := NewCookieEnabledHTTPClient(true)
+
+			rawPath := "/" + strings.TrimPrefix(hashRemotePath, "/")
+			escapedPath := strings.ReplaceAll(rawPath, "#", "%23")
+			target := url.URL{
+				Scheme:  "https",
+				Host:    net.JoinHostPort(sqyrrlConfig.Host, sqyrrlConfig.Port),
+				Path:    rawPath,
+				RawPath: escapedPath,
+			}
+
+			resp, err := httpClient.Get(target.String())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			bodyBytes, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(bodyBytes)).To(Equal("test\n"))
+		}, NodeTimeout(time.Second*5))
 	})
 
 	When("Accessing a file not marked with the public group", func() {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -158,6 +158,43 @@ var _ = Describe("iRODS Get Handler", func() {
 						Expect(rec.Code).To(Equal(http.StatusOK))
 						Expect(rec.Body.String()).To(Equal("test\n"))
 					}, SpecTimeout(specTimeout))
+
+					When("the requested path contains a hash character", func() {
+						var hashRemotePath string
+						var hashGetURL string
+						var hashRequest *http.Request
+
+						BeforeEach(func(ctx SpecContext) {
+							var err error
+
+							hashRemotePath = path.Join(workColl, "hash#test.txt")
+							hashGetURL, err = url.JoinPath(server.EndpointIRODS, hashRemotePath)
+							Expect(err).NotTo(HaveOccurred())
+
+							_, err = irodsFS.UploadFile(localPath, hashRemotePath, "", false, true, true, nil)
+							Expect(err).NotTo(HaveOccurred())
+
+							err = ifs.ChangeDataObjectAccess(conn, hashRemotePath, types.IRODSAccessLevelReadObject,
+								server.IRODSPublicGroup, testZone, false)
+							Expect(err).NotTo(HaveOccurred())
+
+							hashRequest, err = http.NewRequest("GET", hashGetURL, nil)
+							Expect(err).NotTo(HaveOccurred())
+						}, NodeTimeout(time.Second*5))
+
+						AfterEach(func() {
+							err := irodsFS.RemoveFile(hashRemotePath, true)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						It("should serve the correct body content", func(ctx SpecContext) {
+							rec := httptest.NewRecorder()
+							handler.ServeHTTP(rec, hashRequest)
+
+							Expect(rec.Code).To(Equal(http.StatusOK))
+							Expect(rec.Body.String()).To(Equal("test\n"))
+						}, SpecTimeout(specTimeout))
+					})
 				})
 			})
 		})
@@ -606,6 +643,68 @@ var _ = Describe("Seamless Auth Flow", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(bodyBytes)).To(Not(ContainSubstring("test")))
 			}, NodeTimeout(time.Second*2))
+		})
+	})
+
+	When("Accessing a private file whose path contains a hash character", func() {
+		var conn *connection.IRODSConnection
+		var hashRemotePath string
+		var hashGetURL string
+
+		BeforeEach(func(ctx SpecContext) {
+			var err error
+
+			hashRemotePath = path.Join(workColl, "hash#test.txt")
+			hashGetURL, err = url.JoinPath(server.EndpointIRODS, hashRemotePath)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = irodsFS.UploadFile(localPath, hashRemotePath, "", false, true, true, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			conn, err = irodsFS.GetIOConnection()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = ifs.ChangeDataObjectAccess(conn, hashRemotePath, types.IRODSAccessLevelReadObject,
+				server.ParseUser(populatedGroup).Name, testZone, false)
+			Expect(err).NotTo(HaveOccurred())
+		}, NodeTimeout(time.Second*5))
+
+		AfterEach(func() {
+			err := irodsFS.RemoveFile(hashRemotePath, true)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = irodsFS.ReturnIOConnection(conn)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		When("authenticated with a user who has access", func() {
+			BeforeEach(func(ctx SpecContext) {
+				mockoidcServer.UserQueue.Push(&mockoidc.MockUser{
+					Email: server.ParseUser(userNotInPublic).Name + "@whereever.com",
+				})
+			})
+
+			AfterEach(func(ctx SpecContext) {
+				mockoidcServer.UserQueue.Pop()
+			})
+
+			It("should return a 200 OK and correct content", func(ctx SpecContext) {
+				httpClient := NewCookieEnabledHTTPClient(true)
+
+				var wsh *http.Response
+				u := url.URL{
+					Scheme: "https",
+					Host:   net.JoinHostPort(sqyrrlConfig.Host, sqyrrlConfig.Port),
+					Path:   hashGetURL,
+				}
+				wsh, err := httpClient.Get(u.String())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(wsh.StatusCode).To(Equal(http.StatusOK))
+
+				bodyBytes, err := io.ReadAll(wsh.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(bodyBytes)).To(Equal("test\n"))
+			}, NodeTimeout(time.Second*5))
 		})
 	})
 })


### PR DESCRIPTION
All gpt-5-codex medium thinking code.
Fixes #137